### PR TITLE
Continue if response 404d

### DIFF
--- a/LE_FIND_PENDING_AUTHZ.py
+++ b/LE_FIND_PENDING_AUTHZ.py
@@ -58,7 +58,12 @@ def ReviewAuthzViaHTTPS(authz):
 		
 		server_response = http.request('GET',PRODUCTION_CA+ 'acme/authz/' +auth)
 		json_body = json.loads(server_response.data.decode('utf-8'))
-		print('\t Status:' + json_body["status"]+' Domain: ' + json_body["identifier"]["value"] +'  Expires: ' + json_body["expires"])
+
+		if str(json_body['status']) == '404':
+			print('\tStatus: ' + str(json_body["status"]) + ' ' + json_body["detail"] + '\n')
+			continue
+
+		print('\t Status:' + str(json_body["status"]) +' Domain: ' + json_body["identifier"]["value"] +'  Expires: ' + str(json_body["expires"]))
 		if(json_body["status"] == 'pending'):
 			print('Invalidating :'+auth)
 			InvalidateAuth(json_body["challenges"][0]["uri"] , json_body["challenges"][0]["token"])


### PR DESCRIPTION
This PR fixes an issue I had with one of my log entries (body returned status 404). Python interpreted "404" as number so let's explicitly stringify the field. 