### PR TITLE
Making log file path absolute

### DIFF
--- a/LE_FIND_PENDING_AUTHZ.py
+++ b/LE_FIND_PENDING_AUTHZ.py
@@ -95,6 +95,7 @@ def InvalidateAuth(challenge_uri, challenge_token):
 
 MakeACMEJOSEKey()			
 for files in os.listdir(PATH):
+	files = os.path.join(PATH, files)
 	if(FirstFilePass(files)):
 		authz = ExtractAuthz(files)
 		ReviewAuthzViaHTTPS(authz)


### PR DESCRIPTION
Kept getting an error that the log file couldn't be found as it was using a relative path.